### PR TITLE
Add nullable annotations to public surface API

### DIFF
--- a/src/Css/Css.csproj
+++ b/src/Css/Css.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageReference Include="IsExternalInit" Version="1.0.2" PrivateAssets="all" />
     <PackageReference Include="NuGetizer" Version="0.7.5" PrivateAssets="all" />
+    <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="all" />
     <PackageReference Include="Superpower" Version="3.0.0" />
   </ItemGroup>
 

--- a/src/Css/CssSelectorExtensions.cs
+++ b/src/Css/CssSelectorExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Xml.Linq;
@@ -20,8 +21,11 @@ public static class CssSelectorExtensions
     /// <param name="node">The <see cref="XNode"/> on which to evaluate the XPath expression.</param>
     /// <param name="expression">A <see cref="string"/> that contains a CSS3 selector expression.</param>
     /// <returns>An <see cref="XElement"/>, or null.</returns>
-    public static XElement CssSelectElement(this XNode node, string expression)
+    public static XElement? CssSelectElement(this XNode? node, string expression)
     {
+        if (node == null)
+            return null;
+
         var selector = Parser.Parse(expression);
         var xpath = selector.ToXPath();
         return node.XPathSelectElement(xpath);
@@ -35,8 +39,11 @@ public static class CssSelectorExtensions
     /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="XElement"/> that
     /// contains the selected elements.
     /// </returns>
-    public static IEnumerable<XElement> CssSelectElements(this XNode node, string expression)
+    public static IEnumerable<XElement> CssSelectElements(this XNode? node, string expression)
     {
+        if (node == null)
+            return Array.Empty<XElement>();
+
         var selector = Parser.Parse(expression);
         var xpath = selector.ToXPath();
         return node.XPathSelectElements(xpath, new CssContext());

--- a/src/Css/Parser.cs
+++ b/src/Css/Parser.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using Superpower;
-using Superpower.Model;
 using Superpower.Parsers;
 
 namespace Devlooped.Xml.Css;


### PR DESCRIPTION
Both provided extension methods on `XNode` can now accept and return a null value.

Fixes #26