### PR TITLE
Apply single quotes normalization to attribute value matching

### DIFF
--- a/src/Css/Css.cs
+++ b/src/Css/Css.cs
@@ -101,7 +101,7 @@ record AttributeSelector(string Name, string? Value = default, ValueMatching? Ma
         else if (Matching != null)
         {
             // Remove quotes around the value since we always add them back for XPath.
-            var value = Value.Trim('"');
+            var value = Value.Trim('"', '\'');
 
             switch (Matching)
             {

--- a/src/Tests/CssParserTests.cs
+++ b/src/Tests/CssParserTests.cs
@@ -140,7 +140,6 @@ public record CssParserTests(ITestOutputHelper Console)
         Assert.Equal(matching, selector.Matching);
     }
 
-
     [Fact]
     public void CanParseSelector1()
     {

--- a/src/Tests/XPathTests.cs
+++ b/src/Tests/XPathTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Text;
 using System.Xml.Linq;
 using Superpower;
 
@@ -89,5 +90,34 @@ public record XPathTests(ITestOutputHelper Console)
         var div = Parser.SimpleSelectorSequence.Parse("div[title]");
 
         Assert.NotNull(div);
+    }
+
+    [InlineData("[text()=hello world]", "[text()=\"hello world\"]")]
+    [InlineData("[text()='hello world']", "[text()=\"hello world\"]")]
+    [InlineData("[text()=\"hello world\"]", "[text()=\"hello world\"]")]
+    [InlineData("[text()*=\"hello world\"]", "[contains(text(),\"hello world\")]")]
+    [InlineData("[text()*='hello world']", "[contains(text(),\"hello world\")]")]
+    [InlineData("[data='hello world']", "[@data=\"hello world\"]")]
+    [InlineData("[data=hello world]", "[@data=\"hello world\"]")]
+    [InlineData("[data=\"hello world\"]", "[@data=\"hello world\"]")]
+    [InlineData("[data*=\"hello world\"]", "[contains(@data,\"hello world\")]")]
+    [InlineData("[data*='hello world']", "[contains(@data,\"hello world\")]")]
+    [Theory]
+    internal void AttributeSelectorNormalizesQuotes(string expression, string xpath)
+    {
+        var selector = (AttributeSelector)Parser.AttributeSelector.Parse(expression);
+
+        var builder = new StringBuilder();
+        selector.Append(builder);
+
+        Assert.Equal(xpath, builder.ToString());
+    }
+
+
+    [Fact]
+    public void RenderExpression()
+    {
+        var expression = "*[text()$=\"to go\"]";
+        Console.WriteLine(Parser.Parse(expression).ToXPath());
     }
 }


### PR DESCRIPTION
In addition to filling in missing quotes when value has spaces, also support specifying either double or single quotes.

Fixes #30