### PR TITLE
Properly parse underscore in CSS identifiers

### DIFF
--- a/src/Css/Parser.cs
+++ b/src/Css/Parser.cs
@@ -14,9 +14,10 @@ class Parser
 
     // NOTE: we don't perform any validation on identifiers, it's 
     // up to consumers to ensure they provide valid ones. 
+    // See https://www.w3.org/TR/CSS21/syndata.html#value-def-identifier
     internal static TextParser<string> Identifier { get; } =
-        from start in Character.EqualTo('-').Or(Escape).Or(Character.Letter)
-        from rest in Character.EqualTo('-').Or(Escape).Or(Character.LetterOrDigit)
+        from start in Character.EqualTo('-').Or(Character.EqualTo('_')).Or(Escape).Or(Character.Letter)
+        from rest in Character.EqualTo('-').Or(Character.EqualTo('_')).Or(Escape).Or(Character.LetterOrDigit)
                      .Many()
         select start + new string(rest);
 

--- a/src/Tests/XPathTests.cs
+++ b/src/Tests/XPathTests.cs
@@ -61,6 +61,8 @@ public record XPathTests(ITestOutputHelper Console)
     [InlineData("div[tags^=\"selected flow\"] + div", "Archivo")]
     [InlineData("div[role],span", "Warning 1 2 4 5 Standard File Archivo Edit Footer")]
     [InlineData("span:not([text()='4']),div[role]", "Warning 1 2 5 Standard File Archivo Edit Footer")]
+    [InlineData(".item__hiden-content", "Archivo")]
+    //item__hiden-content
     [Theory]
     public void EvaluatePageHtml(string expression, string expected)
     {

--- a/src/Tests/page.html
+++ b/src/Tests/page.html
@@ -20,7 +20,7 @@
         <span>5</span>
         <div role="menubar">Standard</div>
         <div class="menuitem group" role="menuitem" tags="selected flow menu" lang="en-US">File</div>
-        <div class="menuitem group" role="menuitem" lang="es-ar">Archivo</div>
+        <div class="menuitem group item__hiden-content" role="menuitem" lang="es-ar">Archivo</div>
         <div class="menuitem" role="menuitem" tags="flow">Edit</div>
         <form>
             <input type="checkbox" checked="checked" />


### PR DESCRIPTION
See https://www.w3.org/TR/CSS21/syndata.html#value-def-identifier

Fixes #34