### PR TITLE
Add support for simplified syntax for nth-child

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,7 @@ At the moment, supports the following CSS selector features:
     * [:last-of-type](https://www.w3.org/TR/selectors-3/#last-of-type-pseudo)
     * [:not(...)](https://www.w3.org/TR/selectors-3/#negation)
     * [:nth-of-type(n)](https://www.w3.org/TR/selectors-3/#nth-of-type-pseudo)
+    * [:nth-child(n)](https://www.w3.org/TR/selectors-3/#nth-child-pseudo): simplified syntax with just a position only
     * [:has(...)](https://www.w3.org/TR/selectors-4/#has-pseudo)
 
 And all [combinators](https://www.w3.org/TR/selectors-3/#combinators)

--- a/src/Css/Css.cs
+++ b/src/Css/Css.cs
@@ -301,6 +301,12 @@ record PositionSelector(string Position) : SimpleSelector
         => builder.Append("[").Append(Position).Append("]");
 }
 
+record NthChildSelector(string Position) : SimpleSelector
+{
+    public override void Append(StringBuilder builder)
+        => builder.Append("[(count(preceding-sibling::*)+1)=").Append(Position).Append("]");
+}
+
 enum Combinator
 {
     None,

--- a/src/Css/Parser.cs
+++ b/src/Css/Parser.cs
@@ -104,6 +104,7 @@ class Parser
             .Or(Span.EqualTo("last-of-type").Try())
             .Or(Span.EqualTo("not").Try())
             .Or(Span.EqualTo("nth-of-type").Try())
+            .Or(Span.EqualTo("nth-child").Try())
             .Or(Span.EqualTo("has"))
          from argument in PseudoArgumentSelector.OptionalOrDefault()
          select identifier.ToStringValue() switch
@@ -118,6 +119,7 @@ class Parser
              "not" => new NegationSelector(argument),
              "nth-of-type" => (SimpleSelector)argument,
              "has" => new HasSelector(argument),
+             string id when id == "nth-child" && argument is PositionSelector position => new NthChildSelector(position.Position),
              _ => throw new NotSupportedException()
          })
         .Named("pseudo selector");

--- a/src/Tests/CssParserTests.cs
+++ b/src/Tests/CssParserTests.cs
@@ -164,10 +164,15 @@ public record CssParserTests(ITestOutputHelper Console)
     [Fact]
     public void CanParseSelector2()
     {
-        var selector = Parser.Selector.Parse("foo > bar");
+        var selector = Parser.Selector.Parse("foo:nth-child(2)");
+        var xpath = selector.ToXPath();
     }
 
     [InlineData("foo\\+bar", "foo+bar")]
+    [InlineData("foo_bar", "foo_bar")]
+    [InlineData("foo__bar", "foo__bar")]
+    [InlineData("_foo-bar", "_foo-bar")]
+    [InlineData("-foo_bar", "-foo_bar")]
     [Theory]
     public void ParseIdentifier(string expression, string identifier)
         => Assert.Equal(identifier, Parser.Identifier.Parse(expression));

--- a/src/Tests/XPathTests.cs
+++ b/src/Tests/XPathTests.cs
@@ -65,6 +65,8 @@ public record XPathTests(ITestOutputHelper Console)
     [InlineData("span:not([text()='4']),div[role]", "Warning 1 2 5 Standard File Archivo Edit Footer")]
     [InlineData(".item__hiden-content", "Archivo")]
     [InlineData("body > div > span", "1 2 4")]
+    [InlineData("body > div:nth-of-type(3)", "Standard")]
+    [InlineData("body > span:nth-child(5)", "5")]
     [Theory]
     public void EvaluatePageHtml(string expression, string expected)
     {


### PR DESCRIPTION
Only supports a single value, not the full `an+b` parameter syntax.

from https://www.w3.org/TR/selectors-3/#nth-child-pseudo.

Fixes #38