### PR TITLE
Bump files with dotnet-file sync

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -87,3 +87,6 @@ csharp_new_line_before_catch = true
 csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
+
+# xUnit1013: Public method should be marked as test. Allows using records as test classes
+dotnet_diagnostic.xUnit1013.severity = none

--- a/.github/workflows/sponsors.yml
+++ b/.github/workflows/sponsors.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: 🔽 gh 
         run: |
-          iwr -useb get.scoop.sh | iex
+          iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
           scoop install gh
 
       - name: 💛 sponsors

--- a/.netconfig
+++ b/.netconfig
@@ -24,8 +24,8 @@
 	skip
 [file ".editorconfig"]
 	url = https://github.com/devlooped/oss/blob/main/.editorconfig
-	sha = 0683ee777d7d878d4bf013d7deea352685135a05
-	etag = 985aa022503959d35b03c870f07ae604cead7580d260775235ef6665aa9a6cbe
+	sha = 369cd2bd49ce032f616a2fcb4c997535dbe8d9aa
+	etag = 4e857df48d0abd81512350d6b3b1a1c83b78284be65bd5172a4ec8e52cd04e2d
 	weak
 [file ".gitattributes"]
 	url = https://github.com/devlooped/oss/blob/main/.gitattributes
@@ -114,8 +114,8 @@
 	weak
 [file "src/Directory.Build.targets"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.targets
-	sha = 024f73321ffe4e927151ff94666c52c2d425139a
-	etag = 816dff7cb821a885da46ad200f9b8bea3438d74da3172bc43716d5670abaee6c
+	sha = b9fb0a7d34d6c16fb404f9dff4aac6789ef08a00
+	etag = 852b16129d2c681ad6ec86ff56b256541e0ce0961eb3a9492e0ead89ffe5a6bd
 	weak
 [file "src/kzu.snk"]
 	url = https://github.com/devlooped/oss/blob/main/src/kzu.snk
@@ -139,8 +139,8 @@
 	weak
 [file ".github/workflows/sponsors.yml"]
 	url = https://github.com/devlooped/.github/blob/main/.github/workflows/sponsors.yml
-	sha = 514760df24bd906b9e5d3a56deac0d18cba59a6d
-	etag = 0236ed96c1d11f69b26ac0e039e74107df5731574236e2de2a83152fee5df0a6
+	sha = 8b6384e91fdfcf8f3cc9b3b262a9ca2a1095d06a
+	etag = 2c05a753600913f546c37a2ea9393b3ede3b6f8473e5c2d53462aa7342af7078
 	weak
 [file "Gemfile"]
 	url = https://github.com/devlooped/.github/blob/main/Gemfile

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -145,7 +145,6 @@
 
   </Target>
 
-  <!-- Always append the link to the direct source tree for the current build -->
   <Target Name="UpdatePackageMetadata"
           BeforeTargets="PrepareForBuild;GenerateMSBuildEditorConfigFileShouldRun;GetAssemblyVersion;GetPackageMetadata;GenerateNuspec;Pack"
           DependsOnTargets="EnsureProjectInformation"
@@ -153,10 +152,6 @@
                      '$(IsPackable)' == 'true'">
     <PropertyGroup>
       <PackageProjectUrl Condition="'$(PackageProjectUrl)' == '' and '$(PublishRepositoryUrl)' == 'true'">$(RepositoryUrl)</PackageProjectUrl>
-      <Description Condition="'$(RepositorySha)' != '' and '$(RepositoryUrl)' != ''">$(Description)
-
-Built from $(RepositoryUrl)/tree/$(RepositorySha)
-      </Description>
       <PackageDescription>$(Description)</PackageDescription>
       <PackageReleaseNotes Condition="'$(RepositoryUrl)' != '' and Exists('$(MSBuildThisFileDirectory)..\changelog.md')">$(RepositoryUrl)/blob/main/changelog.md</PackageReleaseNotes>
     </PropertyGroup>


### PR DESCRIPTION
# devlooped/oss

- Remove the source link in the package description https://github.com/devlooped/oss/commit/b9fb0a7
- Ignore xUnit1013 so records can be used as test classes https://github.com/devlooped/oss/commit/369cd2b

# devlooped/.github

- Fix for installing gh as admin https://github.com/devlooped/.github/commit/8b6384e